### PR TITLE
InputWithTitleコンポーネントをChakraUIとして使えるようにする

### DIFF
--- a/src/components/InputWithLabel.tsx
+++ b/src/components/InputWithLabel.tsx
@@ -7,18 +7,18 @@ import {
 } from '@chakra-ui/react';
 
 interface Props extends InputProps {
-  title: string;
+  label: string;
 }
 
-function InputWithTitle(props: Props) {
-  const { title, ...inputProps } = props;
+function InputWithLabel(props: Props) {
+  const { label, ...inputProps } = props;
 
   return (
     <>
       <FormControl>
         <FormLabel>
           <Text fontSize="sm" as="b">
-            {title}
+            {label}
           </Text>
         </FormLabel>
         <Input type="email" size="md" width="100%" {...inputProps} />
@@ -27,4 +27,4 @@ function InputWithTitle(props: Props) {
   );
 }
 
-export default InputWithTitle;
+export default InputWithLabel;

--- a/src/components/InputWithTitle.tsx
+++ b/src/components/InputWithTitle.tsx
@@ -1,10 +1,18 @@
-import { FormControl, FormLabel, Input, Text } from '@chakra-ui/react';
+import {
+  FormControl,
+  FormLabel,
+  Input,
+  InputProps,
+  Text
+} from '@chakra-ui/react';
 
-interface TitleProps {
+interface Props extends InputProps {
   title: string;
 }
 
-function InputWithTitle({ title }: TitleProps) {
+function InputWithTitle(props: Props) {
+  const { title, ...inputProps } = props;
+
   return (
     <>
       <FormControl>
@@ -13,7 +21,7 @@ function InputWithTitle({ title }: TitleProps) {
             {title}
           </Text>
         </FormLabel>
-        <Input type="email" size="md" width="100%" />
+        <Input type="email" size="md" width="100%" {...inputProps} />
       </FormControl>
     </>
   );

--- a/src/components/SignInForm.tsx
+++ b/src/components/SignInForm.tsx
@@ -2,13 +2,13 @@
 
 import { Button, VStack, Divider } from '@chakra-ui/react';
 import GoogleGLogo from './GoogleGLogo';
-import InputWithTitle from './InputWithTitle';
+import InputWithLabel from './InputWithLabel';
 
 const SignInForm = () => {
   return (
     <VStack spacing={4}>
-      <InputWithTitle title="メールアドレス" />
-      <InputWithTitle title="パスワード" />
+      <InputWithLabel label="メールアドレス" />
+      <InputWithLabel label="パスワード" />
       <Button colorScheme="blue" size="md" width="100%">
         続ける
       </Button>


### PR DESCRIPTION
# やったこと
- `InputWithTitle` コンポーネントを `InputWithLabel` に名称変更
  - Reactのデフォルトのinput要素が既にtitleプロパティを持っていて、独自にtitleプロパティを与えるのが気持ち悪かったので変更しました。
- `InputWithLabel` がChakraUIのInputコンポーネントのプロパティを受け入れるように
  - Chakra UIのInputと同じ使い心地になる.

# ヒント
無理に全部理解できなくても大丈夫です!
- スプレッド構文 `{...inputProps}` 
参考？: https://commte.net/nextjs-spread-operator
- 分割代入 `{ label, ...inputProps} = props`
- interfaceの継承
参考？: https://typescriptbook.jp/reference/object-oriented/interface/interface-inheritance

closes #3 