### PR TITLE
ForecastStatusLayoutをcolorSchemeに対応

### DIFF
--- a/src/components/forecast-status-block/ForecastStatusLayout.tsx
+++ b/src/components/forecast-status-block/ForecastStatusLayout.tsx
@@ -1,7 +1,8 @@
-import { Box, Text, VStack } from '@chakra-ui/react';
+import { Box, Text, VStack, theme } from '@chakra-ui/react';
 import { PropsWithChildren } from 'react';
 
 interface ForecastStatusProps {
+  colorScheme?: keyof typeof theme.colors;
   badgeText: string;
   description: string;
 }
@@ -9,11 +10,15 @@ interface ForecastStatusProps {
 const ForecastStatusLayout = (
   props: PropsWithChildren<ForecastStatusProps>
 ) => {
+  const colorScheme = props.colorScheme || 'gray';
+  const bg50 = `${colorScheme}.50`;
+  const bg200 = `${colorScheme}.200`;
+
   return (
-    <Box px={4} py={3} width="100%" borderRadius="lg" bg="gray.50">
+    <Box px={4} py={3} width="100%" borderRadius="lg" bg={bg50}>
       <VStack alignItems={'flex-start'}>
         <>
-          <Box borderRadius="2px" bg="gray.100">
+          <Box borderRadius="2px" bg={bg200}>
             <Text as="b" size={'sm'}>
               {props.badgeText}
             </Text>

--- a/src/components/forecast-status-block/PendingStatus.tsx
+++ b/src/components/forecast-status-block/PendingStatus.tsx
@@ -13,6 +13,7 @@ export const Pending = (props: PendingProps) => {
     <ForecastStatusLayout
       badgeText="未確定"
       description={'連絡がまだの人がいます！'}
+      colorScheme="gray"
     >
       <Progress
         colorScheme="progress"
@@ -21,8 +22,12 @@ export const Pending = (props: PendingProps) => {
         value={progressValue}
       />
       <HStack width="100%" justifyContent="space-between">
-        <Text><span className='font-bold'>{props.current}</span>人</Text>
-        <Text>あと <span className='font-bold'>{props.max - props.current}</span>人</Text>
+        <Text>
+          <span className="font-bold">{props.current}</span>人
+        </Text>
+        <Text>
+          あと <span className="font-bold">{props.max - props.current}</span>人
+        </Text>
       </HStack>
     </ForecastStatusLayout>
   );


### PR DESCRIPTION
closes #24 
## 概要
- `<ForecastStatusLayout>`に`colorScheme` propsを追加
- ボックス全体の背景と、Badgeの背景に自動適用
- デフォルトのcolorSchemeはgray

## QA事項
`src/components/forecast-status-block/PendingStatus.tsx` などで
- colorScheme propsを変更すると2つの背景がそれぞれ問題なく変更される
- colorScheme propsを削除するとgrayになる