### PR TITLE
垂直選択コンポーネントを作成

### DIFF
--- a/src/components/vertical-select/VerticalSelect.tsx
+++ b/src/components/vertical-select/VerticalSelect.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import VerticalSelectContext from './hooks/use-vertical-select';
+import { VerticalSelectOptionProps } from './VerticalSelectOption';
+
+interface VerticalSelectProps {
+  children: React.ReactNode;
+  defaultValue?: VerticalSelectOptionProps['value'];
+}
+
+type VerticalSelectValue = VerticalSelectOptionProps['value'] | null;
+
+export const VerticalSelect = ({
+  children,
+  defaultValue
+}: VerticalSelectProps) => {
+  const [selectedValue, setSelectedValue] = useState<VerticalSelectValue>(null);
+  const Provider = VerticalSelectContext.Provider;
+
+  useEffect(() => {
+    if (defaultValue) {
+      setSelectedValue(defaultValue);
+    }
+  }, [defaultValue]);
+
+  return (
+    <Provider
+      value={{
+        selectedValue,
+        setSelectedValue,
+        options: []
+      }}
+    >
+      <div className={'flex flex-col'}>{children}</div>
+    </Provider>
+  );
+};

--- a/src/components/vertical-select/VerticalSelect.tsx
+++ b/src/components/vertical-select/VerticalSelect.tsx
@@ -1,22 +1,27 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState, Children, ReactElement } from 'react';
 import VerticalSelectContext from './hooks/use-vertical-select';
 import { VerticalSelectOptionProps } from './VerticalSelectOption';
+import { VerticalSelectContextType } from './types/vertical-select-context-type';
 
 interface VerticalSelectProps {
   children: React.ReactNode;
   defaultValue?: VerticalSelectOptionProps['value'];
+  itemHeight?: number;
 }
 
 type VerticalSelectValue = VerticalSelectOptionProps['value'] | null;
 
 export const VerticalSelect = ({
   children,
-  defaultValue
+  defaultValue,
+  itemHeight = 48
 }: VerticalSelectProps) => {
   const [selectedValue, setSelectedValue] = useState<VerticalSelectValue>(null);
+  const [selectedIndex, setSelectedIndex] = useState<number>(0);
   const Provider = VerticalSelectContext.Provider;
+  const options = useRef<VerticalSelectContextType['options']>([]);
 
   useEffect(() => {
     if (defaultValue) {
@@ -24,15 +29,45 @@ export const VerticalSelect = ({
     }
   }, [defaultValue]);
 
+  // 渡ってきたchildrenをmapで回して、それぞれのoptionにindexを設定する
+  useEffect(() => {
+    Children.forEach(children, (child, index) => {
+      child = child as ReactElement<VerticalSelectOptionProps>;
+      if (child) {
+        options.current.map((option) => {
+          option.index = index;
+        });
+      }
+    });
+  }, [children]);
+
+  useEffect(() => {
+    setSelectedIndex(
+      options.current.findIndex((option) => option.value === selectedValue)
+    );
+  }, [selectedValue]);
+
   return (
     <Provider
       value={{
         selectedValue,
         setSelectedValue,
-        options: []
+        options: options.current,
+        itemHeight: itemHeight
       }}
     >
-      <div className={'flex flex-col'}>{children}</div>
+      <div className={'relative flex flex-col rounded-md bg-slate-100'}>
+        <div
+          className={
+            'absolute z-0 w-full rounded-md border-2 border-slate-400 bg-white shadow-md transition-all'
+          }
+          style={{
+            transform: `translateY(${selectedIndex * itemHeight}px) `,
+            height: itemHeight
+          }}
+        />
+        <div className="z-20">{children}</div>
+      </div>
     </Provider>
   );
 };

--- a/src/components/vertical-select/VerticalSelect.tsx
+++ b/src/components/vertical-select/VerticalSelect.tsx
@@ -20,6 +20,7 @@ export const VerticalSelect = ({
 }: VerticalSelectProps) => {
   const [selectedValue, setSelectedValue] = useState<VerticalSelectValue>(null);
   const [selectedIndex, setSelectedIndex] = useState<number>(0);
+  const [isOptionsReady, setIsOptionsReady] = useState<boolean>(false);
   const Provider = VerticalSelectContext.Provider;
   const options = useRef<VerticalSelectContextType['options']>([]);
 
@@ -29,21 +30,46 @@ export const VerticalSelect = ({
     }
   }, [defaultValue]);
 
+  useEffect(() => {
+    if (isOptionsReady) {
+      if (!options.current.find((option) => option.value === defaultValue)) {
+        console.error(`Invalid defaultValue: ${defaultValue}`);
+      }
+      if (defaultValue) {
+        setSelectedIndex(
+          options.current.find((option) => option.value === defaultValue)
+            ?.index || 0
+        );
+      } else {
+        setSelectedIndex(0);
+      }
+    }
+  }, [isOptionsReady, defaultValue]);
+
   // 渡ってきたchildrenをmapで回して、それぞれのoptionにindexを設定する
   useEffect(() => {
     Children.forEach(children, (child, index) => {
       child = child as ReactElement<VerticalSelectOptionProps>;
       if (child) {
-        options.current.map((option) => {
-          option.index = index;
+        options.current.forEach((option) => {
+          if (option.value === child.props.value) option.index = index;
         });
       }
+
+      // 全てのoptionにindexが設定された時の処理
+      if (
+        Children.count(children) ===
+        options.current.filter((option) => option.index !== undefined).length
+      ) {
+        setIsOptionsReady(true);
+      }
     });
-  }, [children]);
+  }, [children, defaultValue]);
 
   useEffect(() => {
     setSelectedIndex(
-      options.current.findIndex((option) => option.value === selectedValue)
+      options.current.find((option) => option.value === selectedValue)?.index ||
+        0
     );
   }, [selectedValue]);
 

--- a/src/components/vertical-select/VerticalSelect.tsx
+++ b/src/components/vertical-select/VerticalSelect.tsx
@@ -7,7 +7,7 @@ import { VerticalSelectContextType } from './types/vertical-select-context-type'
 
 interface VerticalSelectProps {
   children: React.ReactNode;
-  defaultValue?: VerticalSelectOptionProps['value'];
+  value?: VerticalSelectOptionProps['value'];
   itemHeight?: number;
 }
 
@@ -15,7 +15,7 @@ type VerticalSelectValue = VerticalSelectOptionProps['value'] | null;
 
 export const VerticalSelect = ({
   children,
-  defaultValue,
+  value: defaultValue,
   itemHeight = 48
 }: VerticalSelectProps) => {
   const [selectedValue, setSelectedValue] = useState<VerticalSelectValue>(null);
@@ -23,6 +23,7 @@ export const VerticalSelect = ({
   const [isOptionsReady, setIsOptionsReady] = useState<boolean>(false);
   const Provider = VerticalSelectContext.Provider;
   const options = useRef<VerticalSelectContextType['options']>([]);
+  const itemCount = Children.count(children);
 
   useEffect(() => {
     if (defaultValue) {
@@ -85,15 +86,27 @@ export const VerticalSelect = ({
       <div className={'relative flex flex-col rounded-md bg-slate-100'}>
         <div
           className={
-            'absolute z-0 w-full rounded-md border-2 border-slate-400 bg-white shadow-md transition-all'
+            'absolute z-0 rounded-md border-2 border-slate-400 bg-white shadow-md transition-all'
           }
           style={{
-            transform: `translateY(${selectedIndex * itemHeight}px) `,
-            height: itemHeight
+            transform: `translateY(${selectedIndex * itemHeight - 2}px) translateX(-3px)`,
+            width: 'calc(100% + 6px)',
+            height: `${itemHeight + 4}px`
           }}
         />
+        {Array(itemCount - 1).map((_, index) => (
+          <Divider key={index} />
+        ))}
         <div className="z-20">{children}</div>
       </div>
     </Provider>
+  );
+};
+
+const Divider = () => {
+  return (
+    <div className="absolute w-full">
+      <div className="mx-5 rounded-full border-t-2 border-slate-300" />
+    </div>
   );
 };

--- a/src/components/vertical-select/VerticalSelect.tsx
+++ b/src/components/vertical-select/VerticalSelect.tsx
@@ -86,7 +86,7 @@ export const VerticalSelect = ({
       <div className={'relative flex flex-col rounded-md bg-slate-100'}>
         <div
           className={
-            'absolute z-0 rounded-md border-2 border-slate-400 bg-white shadow-md transition-all'
+            'absolute z-10 rounded-md border-2 border-slate-400 bg-white shadow-md transition-all'
           }
           style={{
             transform: `translateY(${selectedIndex * itemHeight - 2}px) translateX(-3px)`,
@@ -94,19 +94,26 @@ export const VerticalSelect = ({
             height: `${itemHeight + 4}px`
           }}
         />
-        {Array(itemCount - 1).map((_, index) => (
-          <Divider key={index} />
-        ))}
+        <div className="z-0">
+          {[...Array(itemCount - 1)].map((_, index) => {
+            return <Divider key={index} posY={(index + 1) * itemHeight} />;
+          })}
+        </div>
         <div className="z-20">{children}</div>
       </div>
     </Provider>
   );
 };
 
-const Divider = () => {
+const Divider = ({ posY }: { posY: number }) => {
   return (
     <div className="absolute w-full">
-      <div className="mx-5 rounded-full border-t-2 border-slate-300" />
+      <div
+        className="mx-5 rounded-full border-t-2 border-slate-200"
+        style={{
+          transform: `translateY(${posY - 1}px)`
+        }}
+      />
     </div>
   );
 };

--- a/src/components/vertical-select/VerticalSelectOption.tsx
+++ b/src/components/vertical-select/VerticalSelectOption.tsx
@@ -2,7 +2,7 @@
 
 import { useContext, useEffect, useRef, useState } from 'react';
 import VerticalSelectContext from './hooks/use-vertical-select';
-import clsx from 'clsx';
+import clsx, { ClassValue } from 'clsx';
 
 export type VerticalSelectOptionProps = {
   value: string | number;
@@ -22,7 +22,7 @@ export const VerticalSelectOption = (props: VerticalSelectOptionProps) => {
     );
   }
 
-  const { selectedValue, setSelectedValue, options } = context;
+  const { selectedValue, setSelectedValue, options, itemHeight } = context;
 
   const handleClick = () => {
     setSelectedValue(props.value);
@@ -38,7 +38,7 @@ export const VerticalSelectOption = (props: VerticalSelectOptionProps) => {
       const index = options.findIndex((option) => option.value === props.value);
       options.splice(index, 1);
     };
-  });
+  }, [options, props]);
 
   useEffect(() => {
     setIsSelected(selectedValue === props.value);
@@ -46,12 +46,16 @@ export const VerticalSelectOption = (props: VerticalSelectOptionProps) => {
 
   return (
     <div
-      className={clsx('flex justify-between', isSelected && 'bg-gray-200')}
+      className={clsx(
+        'flex cursor-pointer items-center justify-between px-6',
+        isSelected && 'font-semibold'
+      )}
+      style={{ height: itemHeight }}
       onClick={handleClick}
       ref={ref}
     >
-      <div className={'flex items-center'}>
-        {props.leftIcon && <div className="mr-2">{props.leftIcon}</div>}
+      <div className={'flex items-center gap-3'}>
+        <div className="size-4">{props.leftIcon}</div>
         <div>{props.children}</div>
       </div>
       {props.subText && (

--- a/src/components/vertical-select/VerticalSelectOption.tsx
+++ b/src/components/vertical-select/VerticalSelectOption.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { useContext, useEffect, useRef, useState } from 'react';
+import VerticalSelectContext from './hooks/use-vertical-select';
+import clsx from 'clsx';
+
+export type VerticalSelectOptionProps = {
+  value: string | number;
+  leftIcon?: React.ReactNode;
+  children: React.ReactNode;
+  subText?: string;
+};
+
+export const VerticalSelectOption = (props: VerticalSelectOptionProps) => {
+  const context = useContext(VerticalSelectContext);
+  const [isSelected, setIsSelected] = useState<boolean>(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  if (!context) {
+    throw new Error(
+      'Option component must be used within a VerticalSelect component'
+    );
+  }
+
+  const { selectedValue, setSelectedValue, options } = context;
+
+  const handleClick = () => {
+    setSelectedValue(props.value);
+  };
+
+  useEffect(() => {
+    if (options.some((option) => option.value === props.value)) {
+      throw new Error(`Duplicate value: ${props.value}`);
+    } else {
+      options.push({ ...props, ref: ref.current });
+    }
+    return () => {
+      const index = options.findIndex((option) => option.value === props.value);
+      options.splice(index, 1);
+    };
+  });
+
+  useEffect(() => {
+    setIsSelected(selectedValue === props.value);
+  }, [selectedValue, props.value]);
+
+  return (
+    <div
+      className={clsx('flex justify-between', isSelected && 'bg-gray-200')}
+      onClick={handleClick}
+      ref={ref}
+    >
+      <div className={'flex items-center'}>
+        {props.leftIcon && <div className="mr-2">{props.leftIcon}</div>}
+        <div>{props.children}</div>
+      </div>
+      {props.subText && (
+        <div className="text-sm text-gray-400">{props.subText}</div>
+      )}
+    </div>
+  );
+};

--- a/src/components/vertical-select/VerticalSelectOption.tsx
+++ b/src/components/vertical-select/VerticalSelectOption.tsx
@@ -3,6 +3,7 @@
 import { useContext, useEffect, useRef, useState } from 'react';
 import VerticalSelectContext from './hooks/use-vertical-select';
 import clsx from 'clsx';
+import clickOrTap from './utils/clickOrTap';
 
 export type VerticalSelectOptionProps = {
   value: string | number;
@@ -52,8 +53,8 @@ export const VerticalSelectOption = (props: VerticalSelectOptionProps) => {
         isSelected && 'font-semibold'
       )}
       style={{ height: itemHeight }}
-      onClick={handleClick}
       ref={ref}
+      {...clickOrTap(handleClick)}
     >
       <div className={'flex items-center gap-3'}>
         <div className="size-4">

--- a/src/components/vertical-select/VerticalSelectOption.tsx
+++ b/src/components/vertical-select/VerticalSelectOption.tsx
@@ -30,7 +30,7 @@ export const VerticalSelectOption = (props: VerticalSelectOptionProps) => {
 
   useEffect(() => {
     if (options.some((option) => option.value === props.value)) {
-      throw new Error(`Duplicate value: ${props.value}`);
+      console.error(`Duplicate value: ${props.value}`);
     } else {
       options.push({ ...props, ref: ref.current });
     }

--- a/src/components/vertical-select/VerticalSelectOption.tsx
+++ b/src/components/vertical-select/VerticalSelectOption.tsx
@@ -2,11 +2,12 @@
 
 import { useContext, useEffect, useRef, useState } from 'react';
 import VerticalSelectContext from './hooks/use-vertical-select';
-import clsx, { ClassValue } from 'clsx';
+import clsx from 'clsx';
 
 export type VerticalSelectOptionProps = {
   value: string | number;
   leftIcon?: React.ReactNode;
+  selectedLeftIcon?: React.ReactNode;
   children: React.ReactNode;
   subText?: string;
 };
@@ -55,7 +56,11 @@ export const VerticalSelectOption = (props: VerticalSelectOptionProps) => {
       ref={ref}
     >
       <div className={'flex items-center gap-3'}>
-        <div className="size-4">{props.leftIcon}</div>
+        <div className="size-4">
+          {props.selectedLeftIcon && isSelected
+            ? props.selectedLeftIcon
+            : props.leftIcon}
+        </div>
         <div>{props.children}</div>
       </div>
       {props.subText && (

--- a/src/components/vertical-select/VerticalSelectOption.tsx
+++ b/src/components/vertical-select/VerticalSelectOption.tsx
@@ -49,24 +49,31 @@ export const VerticalSelectOption = (props: VerticalSelectOptionProps) => {
   return (
     <div
       className={clsx(
-        'flex cursor-pointer items-center justify-between px-6',
-        isSelected && 'font-semibold'
+        'group flex cursor-pointer items-center p-1.5 text-slate-700',
+        isSelected && 'font-semibold text-slate-950'
       )}
-      style={{ height: itemHeight }}
       ref={ref}
+      style={{ height: itemHeight }}
       {...clickOrTap(handleClick)}
     >
-      <div className={'flex items-center gap-3'}>
-        <div className="size-4">
-          {props.selectedLeftIcon && isSelected
-            ? props.selectedLeftIcon
-            : props.leftIcon}
+      <div
+        className={clsx(
+          'flex size-full items-center justify-between rounded px-4 transition-colors duration-150',
+          !isSelected && 'group-hover:bg-slate-400/10'
+        )}
+      >
+        <div className={'flex items-center gap-3'}>
+          <div className="size-4">
+            {props.selectedLeftIcon && isSelected
+              ? props.selectedLeftIcon
+              : props.leftIcon}
+          </div>
+          <div>{props.children}</div>
         </div>
-        <div>{props.children}</div>
+        {props.subText && (
+          <div className="text-sm text-gray-400">{props.subText}</div>
+        )}
       </div>
-      {props.subText && (
-        <div className="text-sm text-gray-400">{props.subText}</div>
-      )}
     </div>
   );
 };

--- a/src/components/vertical-select/hooks/use-vertical-select.ts
+++ b/src/components/vertical-select/hooks/use-vertical-select.ts
@@ -1,0 +1,8 @@
+import { createContext } from 'react';
+import { VerticalSelectContextType } from '../types/vertical-select-context-type';
+
+const VerticalSelectContext = createContext<VerticalSelectContextType | null>(
+  null
+);
+
+export default VerticalSelectContext;

--- a/src/components/vertical-select/types/vertical-select-context-type.ts
+++ b/src/components/vertical-select/types/vertical-select-context-type.ts
@@ -1,0 +1,8 @@
+import { Dispatch } from 'react';
+import { VerticalSelectOptionProps } from '../VerticalSelectOption';
+
+export interface VerticalSelectContextType {
+  selectedValue: VerticalSelectOptionProps['value'] | null;
+  setSelectedValue: Dispatch<VerticalSelectOptionProps['value']>;
+  options: (VerticalSelectOptionProps & { ref: HTMLElement | null })[];
+}

--- a/src/components/vertical-select/types/vertical-select-context-type.ts
+++ b/src/components/vertical-select/types/vertical-select-context-type.ts
@@ -4,5 +4,9 @@ import { VerticalSelectOptionProps } from '../VerticalSelectOption';
 export interface VerticalSelectContextType {
   selectedValue: VerticalSelectOptionProps['value'] | null;
   setSelectedValue: Dispatch<VerticalSelectOptionProps['value']>;
-  options: (VerticalSelectOptionProps & { ref: HTMLElement | null })[];
+  options: (VerticalSelectOptionProps & {
+    ref: HTMLElement | null;
+    index?: number;
+  })[];
+  itemHeight: number;
 }

--- a/src/components/vertical-select/utils/clickOrTap.ts
+++ b/src/components/vertical-select/utils/clickOrTap.ts
@@ -1,0 +1,50 @@
+import { MouseEventHandler, TouchEventHandler } from 'react';
+
+export default function clickOrTap(handler: any) {
+  const onClick: MouseEventHandler<HTMLDivElement> = (event) => {
+    if (typeof handler === 'function') {
+      handler(event);
+    }
+  };
+
+  const onTouchEnd: TouchEventHandler<HTMLDivElement> = (event) => {
+    if (event.cancelable === false) {
+      // スクロール時はcancellable === falseなのでハンドラーを呼ばない
+      return;
+    }
+
+    const touch = event.changedTouches[0];
+    if (event.currentTarget instanceof HTMLElement) {
+      handler(event);
+      const bound = event.currentTarget?.getBoundingClientRect();
+
+      if (
+        touch.clientX < bound.left ||
+        touch.clientX > bound.right ||
+        touch.clientY < bound.top ||
+        touch.clientY > bound.bottom
+      ) {
+        // 領域外で指を離したらハンドラーを呼ばない
+        event.preventDefault();
+        event.stopPropagation();
+        return;
+      }
+
+      if (
+        handler == null &&
+        ['INPUT', 'SELECT', 'TEXTAREA'].includes(event.currentTarget.tagName)
+      ) {
+        event.currentTarget.focus();
+      } else {
+        if (typeof handler === 'function') {
+          handler(event);
+        }
+      }
+    }
+  };
+
+  return {
+    onClick,
+    onTouchEnd
+  };
+}


### PR DESCRIPTION
closes #32 
## やったこと
- 連絡タブでステータスを編集するための垂直選択のコンポーネントを作成する

## スクリーンショット
<img width="391" alt="image" src="https://github.com/k4nkan/watnow-2024-spring-project/assets/12378384/c53494f4-c687-46af-8fb7-24d82efc4fc3">

## 影響箇所
なし

## 備考
<details><summary>スクリーンショットを再現するデモのコード</summary>
<p>

```typescript
'use client';

import { VerticalSelectOption as Option } from '@/components/vertical-select/VerticalSelectOption';
import { VerticalSelect } from '@/components/vertical-select/VerticalSelect';
import { BowlFood, Cookie, Onigiri } from '@phosphor-icons/react';

export default function Page() {
  return (
    <div className="m-10">
      <VerticalSelect value={'normal'} itemHeight={56}>
        <Option
          value={'less'}
          leftIcon={<Cookie />}
          selectedLeftIcon={<Cookie weight="bold" />}
          subText={'1杯'}
        >
          少なめに
        </Option>
        <Option
          value={'normal'}
          leftIcon={<Onigiri />}
          selectedLeftIcon={<Onigiri weight="bold" />}
          subText={'1.5杯'}
        >
          普段通り
        </Option>
        <Option
          value={'more'}
          leftIcon={<BowlFood />}
          selectedLeftIcon={<BowlFood weight="bold" />}
          subText={'2杯'}
        >
          たくさん
        </Option>
      </VerticalSelect>
    </div>
  );
}

```

</p>
</details> 